### PR TITLE
Db name fix

### DIFF
--- a/scripts/lib/data.py
+++ b/scripts/lib/data.py
@@ -1,5 +1,6 @@
 # -*- Mode: Python; indent-tabs-mode: t; python-indent: 4; tab-width: 4 -*-
 
+import dbm
 import shelve
 from copy import deepcopy
 
@@ -57,6 +58,9 @@ class DataStore:
 
 	def load_from_file(self, dbfile):
 		"""Load database from file"""
+		if dbm.whichdb(dbfile) == '':
+			dbfile = dbfile[:dbfile.rfind('.')]
+
 		try:
 			with shelve.open(dbfile) as newdb:
 				for key in newdb:

--- a/scripts/lib/data.py
+++ b/scripts/lib/data.py
@@ -16,6 +16,14 @@ _default_section = {
 
 class DataStore:
 	"""Shelve database handler"""
+
+	@staticmethod
+	def strip_extension(db_filename):
+		"""Strips the underlying database extension from a file name"""
+		return db_filename[:db_filename.rfind('.')] \
+			if dbm.whichdb(db_filename) == '' \
+			else db_filename
+
 	def __init__(self, dbfile, ddate=None, dsection='default'):
 		self.db = shelve.open(dbfile, writeback=True)
 		self.dsection = dsection
@@ -50,7 +58,7 @@ class DataStore:
 	def save_to_file(self, dbfile):
 		"""Save current database to file"""
 		try:
-			with shelve.open(dbfile) as newdb:
+			with shelve.open(self.strip_extension(dbfile)) as newdb:
 				for key in self.db:
 					newdb[key] = self.db[key]
 		except Exception as e:
@@ -58,11 +66,8 @@ class DataStore:
 
 	def load_from_file(self, dbfile):
 		"""Load database from file"""
-		if dbm.whichdb(dbfile) == '':
-			dbfile = dbfile[:dbfile.rfind('.')]
-
 		try:
-			with shelve.open(dbfile) as newdb:
+			with shelve.open(self.strip_extension(dbfile)) as newdb:
 				for key in newdb:
 					self.db[key] = newdb[key]
 		except Exception as e:

--- a/scripts/lib/data.py
+++ b/scripts/lib/data.py
@@ -21,7 +21,7 @@ class DataStore:
 	def strip_extension(db_filename):
 		"""Strips the underlying database extension from a file name"""
 		return db_filename[:db_filename.rfind('.')] \
-			if dbm.whichdb(db_filename) == '' \
+			if dbm.whichdb(db_filename) == 'dbm.ndbm' \
 			else db_filename
 
 	def __init__(self, dbfile, ddate=None, dsection='default'):


### PR DESCRIPTION
I'm not a super-expert about this, but it seems like shelve fails to load a db file if the filename contains the implementation-specific extension already. The fix just strips the extension if dbm can not find any suitable implementation for the file.