### PR TITLE
Db name fix (pt. 2)

### DIFF
--- a/scripts/lib/data.py
+++ b/scripts/lib/data.py
@@ -20,9 +20,10 @@ class DataStore:
 
 	@staticmethod
 	def strip_extension(db_filename):
-		"""Strips the underlying database extension from a file name"""
-		return os.path.splitext(db_filename)[0] \
-			if dbm.whichdb(db_filename) == 'dbm.ndbm' \
+		"""Strips the underlying database extension for ndbm databases"""
+		ndbm_filename = os.path.splitext(db_filename)[0]
+		return ndbm_filename \
+			if dbm.whichdb(ndbm_filename) == 'dbm.ndbm' \
 			else db_filename
 
 	def __init__(self, dbfile, ddate=None, dsection='default'):


### PR DESCRIPTION
Original one here: https://github.com/worron/ACYLS/pull/16

I'm sorry pal, but I didn't test properly and it didn't work. I've tested now in these scenarios, tell me if you come up with anything else:

- No GNU dbm implementation installed, so ndbm is forced. Both save and load. :heavy_check_mark:
- GNU dbm installed, both save and reload of GNU dbm databases. :heavy_check_mark:
- With GNU dbm installed, load a NDBM file (the one generated previously). :heavy_check_mark:
- With no GNU dbm installed, load a GNU dbm database. Fails to load it, with proper error message about `dbm.gnu` module missing. :heavy_check_mark:
